### PR TITLE
CASMUSER-2838 Fix algol60 zypper repo path

### DIFF
--- a/uai-images/basic_uai/Dockerfile
+++ b/uai-images/basic_uai/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp2:latest
 
-RUN zypper addrepo --no-gpgcheck -f https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/ algol60
+RUN zypper addrepo --no-gpgcheck -f https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2 algol60
 RUN zypper ref && \
     zypper update -y && \
     zypper install -y curl \

--- a/uai-images/broker_uai/Dockerfile
+++ b/uai-images/broker_uai/Dockerfile
@@ -24,7 +24,7 @@ FROM arti.dev.cray.com/baseos-docker-master-local/sles15sp2:latest as base
 
 RUN zypper ref
 RUN zypper update -y
-RUN zypper addrepo --no-gpgcheck -f https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/ algol60
+RUN zypper addrepo --no-gpgcheck -f https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2 algol60
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary and Scope

The algol60 zypper repo URL was incorrect (obsolete) for the basic and broker UAI images so RPMs were not updating.  This fixes the URL in both dockerfiles.

The change is backward comatible.

## Issues and Related PRs

None

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Built and verified that the correct RPM versions were installed.  Deployed on vshasta and verified that the correct RPM versions were in the UAIs.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? y
- Were continuous integration tests run? If not, why? N/A
- Was upgrade tested? If not, why? y
- Was downgrade tested? If not, why? y
- Were new tests (or test issues/Jiras) created for this change? N/A

## Risks and Mitigations

No known risks


## Pull Request Checklist

- [ N/A ] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ N/A ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ N/A ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
