### PR TITLE
CASMINST-5612 Deprecate artifactory-algol60-readonly-file jenkins credential

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -76,9 +76,8 @@ pipeline {
             parallel {
                 stage('Image') {
                     steps {
-                        withCredentials([
-                            file(credentialsId: 'artifactory-algol60-readonly-file', variable: 'ARTIFACTORY_SECRET_FILE')]) {
-                                sh "make docker"
+                        script {
+                            sh "make docker"
                         }
                     }
                 }

--- a/uai-images/basic_uai/Dockerfile
+++ b/uai-images/basic_uai/Dockerfile
@@ -24,7 +24,7 @@
 FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.3 as base
 
 COPY zypper.sh /
-RUN --mount=type=secret,id=sles ./zypper.sh && rm /zypper.sh
+RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTIFACTORY_READONLY_TOKEN ./zypper.sh && rm /zypper.sh
 
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 

--- a/uai-images/basic_uai/Makefile
+++ b/uai-images/basic_uai/Makefile
@@ -29,7 +29,7 @@ ARTIFACTORY_SECRET_FILE ?= ../../secret-file
 all: docker
 
 docker:
-	DOCKER_BUILDKIT=1 docker build --pull ${BASIC_UAI_DOCKER_ARGS} --secret id=sles,src=${ARTIFACTORY_SECRET_FILE} --tag '${BASIC_UAI_IMAGE_NAME}:${VERSION}' .
+	DOCKER_BUILDKIT=1 docker build --pull ${BASIC_UAI_DOCKER_ARGS} --tag '${BASIC_UAI_IMAGE_NAME}:${VERSION}' .
 
 # No unit test for this image
 unit_test:

--- a/uai-images/basic_uai/zypper.sh
+++ b/uai-images/basic_uai/zypper.sh
@@ -2,7 +2,8 @@
 set -e +xv
 trap "rm -rf /root/.zypp" EXIT
 
-source /run/secrets/sles
+ARTIFACTORY_USERNAME=$(test -f /run/secrets/ARTIFACTORY_READONLY_USER && cat /run/secrets/ARTIFACTORY_READONLY_USER)
+ARTIFACTORY_PASSWORD=$(test -f /run/secrets/ARTIFACTORY_READONLY_TOKEN && cat /run/secrets/ARTIFACTORY_READONLY_TOKEN)
 SLES_MIRROR="https://${ARTIFACTORY_USERNAME:-}${ARTIFACTORY_PASSWORD+:}${ARTIFACTORY_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
 SLES_VERSION=15-SP3
 ARCH=x86_64

--- a/uai-images/broker_uai/Dockerfile
+++ b/uai-images/broker_uai/Dockerfile
@@ -24,14 +24,14 @@
 FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.3 as base
 
 COPY zypper.sh /
-RUN --mount=type=secret,id=sles ./zypper.sh && rm /zypper.sh
+RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTIFACTORY_READONLY_TOKEN ./zypper.sh && rm /zypper.sh
 
 WORKDIR /app
 
 FROM base as build 
 
 COPY zypper-csm.sh /
-RUN --mount=type=secret,id=sles /zypper-csm.sh && rm /zypper-csm.sh
+RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTIFACTORY_READONLY_TOKEN /zypper-csm.sh && rm /zypper-csm.sh
 
 RUN ( \
      cd /usr/src/packages/SOURCES && \

--- a/uai-images/broker_uai/Makefile
+++ b/uai-images/broker_uai/Makefile
@@ -29,7 +29,7 @@ ARTIFACTORY_SECRET_FILE ?= ../../secret-file
 all: docker
 
 docker:
-	DOCKER_BUILDKIT=1 docker build --pull ${BROKER_UAI_DOCKER_ARGS} --secret id=sles,src=${ARTIFACTORY_SECRET_FILE} --tag '${BROKER_UAI_IMAGE_NAME}:${VERSION}' .
+	DOCKER_BUILDKIT=1 docker build --pull ${BROKER_UAI_DOCKER_ARGS} --tag '${BROKER_UAI_IMAGE_NAME}:${VERSION}' .
 
 # No unit test for this image
 unit_test:

--- a/uai-images/broker_uai/zypper-csm.sh
+++ b/uai-images/broker_uai/zypper-csm.sh
@@ -2,7 +2,8 @@
 set -e +xv
 trap "rm -rf /root/.zypp" EXIT
 
-source /run/secrets/sles
+ARTIFACTORY_USERNAME=$(test -f /run/secrets/ARTIFACTORY_READONLY_USER && cat /run/secrets/ARTIFACTORY_READONLY_USER)
+ARTIFACTORY_PASSWORD=$(test -f /run/secrets/ARTIFACTORY_READONLY_TOKEN && cat /run/secrets/ARTIFACTORY_READONLY_TOKEN)
 zypper --non-interactive rr --all
 zypper addrepo --no-gpgcheck -f https://${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2 algol60
 zypper --non-interactive source-install cray-switchboard

--- a/uai-images/broker_uai/zypper.sh
+++ b/uai-images/broker_uai/zypper.sh
@@ -2,7 +2,8 @@
 set -e +xv
 trap "rm -rf /root/.zypp" EXIT
 
-source /run/secrets/sles
+ARTIFACTORY_USERNAME=$(test -f /run/secrets/ARTIFACTORY_READONLY_USER && cat /run/secrets/ARTIFACTORY_READONLY_USER)
+ARTIFACTORY_PASSWORD=$(test -f /run/secrets/ARTIFACTORY_READONLY_TOKEN && cat /run/secrets/ARTIFACTORY_READONLY_TOKEN)
 SLES_MIRROR="https://${ARTIFACTORY_USERNAME:-}${ARTIFACTORY_PASSWORD+:}${ARTIFACTORY_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
 SLES_VERSION=15-SP3
 ARCH=x86_64


### PR DESCRIPTION
## Summary and Scope

Existing credential `artifactory-algol60-readonly` of type "Username/Password" should be sufficient. Credential `artifactory-algol60-readonly-file` of type `Secret file` is specific to implementation, less secure (structured content is harder to track in logs) and redundant, so it was decided to deprecate it.

This change converts a single secret mount named `sles` to 2 separate secret mounts named `ARTIFACTORY_READONLY_USERNAME` and `ARTIFACTORY_READONLY_TOKEN` respectively. File for these mounts and command line options are provided by jenkins shared library out of the box, no need to create files and modify `docker build` command line.

## Issues and Related PRs

* Resolves [CASMINST-5612](https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5612)

## Testing
### Tested on:

  * Jenkins

### Test description:
Successfully built images against `sles-mirror` repo which requires authentication.

## Risks and Mitigations
Low - build process change only.
